### PR TITLE
Fixing a minor but misleading documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ app_key_id    8f412eca-e899-4af9-8e38-33302321d3f7
 ```sh
 $ vault write datadog/roles/test \
     app_key_scopes=incident_read,usage_read \
-    default_ttl=1h max_ttl=3h
+    ttl=1h max_ttl=3h
 ```
 
 ```sh


### PR DESCRIPTION
closes #3 
There was a small issue in the docs where I used `default_ttl` instead of `ttl` (the actual parameter). This is probably a leftover artifact from following the tutorial.